### PR TITLE
remove force to failOnWarning.

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './app/scripts/app.js',
   eslint: {
     configFile: '.eslintrc.json',
-    failOnWarning: true,
+    failOnWarning: false,
     failOnError: true
   },
   output: {


### PR DESCRIPTION
Forcing to `failOnWarning` is to strict will cause the developer performance to slow down.
We should use warnings as a way to keep the dev aware not forbid.

What are your thoughts on it @brianfegan 