### PR TITLE
improve webpack and bump packages to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,24 +8,24 @@
     "watch": "gulp watch"
   },
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.17",
-    "babel-loader": "^6.2.0",
-    "babel-plugin-react-transform": "^2.0.0-beta1",
+    "babel-cli": "^6.4.0",
+    "babel-core": "^6.3.26",
+    "babel-loader": "^6.2.1",
+    "babel-plugin-react-transform": "^2.0.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "del": "^2.2.0",
-    "eslint": "^1.8.0",
+    "eslint": "^1.10.3",
     "eslint-loader": "^1.2.0",
-    "eslint-plugin-react": "^3.7.1",
+    "eslint-plugin-react": "^3.14.0",
     "gulp": "^3.9.0",
     "gulp-imagemin": "^2.4.0",
-    "gulp-sass": "^2.1.0",
+    "gulp-sass": "^2.1.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",
     "run-sequence": "^1.1.5",
-    "webpack": "^1.12.2",
+    "webpack": "^1.12.10",
     "webpack-config-merger": "0.0.3"
   }
 }

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -23,10 +23,7 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
-        loader: ['babel'],
-        query: {
-          presets: ['react', 'es2015']
-        }
+        loaders: ['babel']
       }
     ]
   },


### PR DESCRIPTION
Besides upgrading the packages to latest version I improved the webpack file when loading babel.

Here's a quick explanation of why (Check the commit for better understanding on the code).

1. `loader` should be `loaders` since we can load multiple modules and because an array is in use.
2. because we have `.babelrc` file `query` isn't necessary, `.babelrc` is the standard and where the modules for babel need to be pulled so that will keep webpack cleaner.